### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the sysinternals cookb
 
 ## Unreleased
 
+- resolved cookstyle error: recipes/default.rb:34:5 refactor: `Chef/RedundantCode/UseCreateIfMissing`
+- resolved cookstyle error: recipes/procexp.rb:22:3 refactor: `Chef/RedundantCode/UseCreateIfMissing`
 ## 1.1.3 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,7 +31,7 @@ node['sysinternals']['tools'].each do |toolname, url|
   exe = ::File.join(node['sysinternals']['install_dir'], ::File.basename(url))
   remote_file exe do
     source url
-    not_if { ::File.exist? exe }
+    action :create_if_missing
   end
   # disable popup, we accept the EULA!
   # http://peter.hahndorf.eu/blog/2010/03/07/WorkAroundSysinternalsLicensePopups.aspx

--- a/recipes/procexp.rb
+++ b/recipes/procexp.rb
@@ -19,7 +19,7 @@ end
 exe = ::File.join(node['sysinternals']['install_dir'], ::File.basename(node['sysinternals']['procexp']['url']))
 remote_file exe do
   source node['sysinternals']['procexp']['url']
-  not_if { ::File.exist? exe }
+  action :create_if_missing
 end
 
 # Accept the EULA


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.30.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with recipes/default.rb

 - 34:5 refactor: `Chef/RedundantCode/UseCreateIfMissing` - Use the :create_if_missing action instead of not_if with a ::File.exist(FOO) check. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_usecreateifmissing)

### Issues found and resolved with recipes/procexp.rb

 - 22:3 refactor: `Chef/RedundantCode/UseCreateIfMissing` - Use the :create_if_missing action instead of not_if with a ::File.exist(FOO) check. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_usecreateifmissing)